### PR TITLE
Remove all trailing nulls from OpenCL API info strings

### DIFF
--- a/src/info_type.rs
+++ b/src/info_type.rs
@@ -40,8 +40,8 @@ impl InfoType {
     pub fn to_str(self) -> Result<CString, NulError> {
         match self {
             InfoType::Str(mut a) => {
-                // remove the trailing null if there is one
-                if let Some(0) = a.last() {
+                // remove all trailing nulls if any
+                while let Some(0) = a.last() {
                     a.pop();
                 }
                 CString::new(a)


### PR DESCRIPTION
Info strings returned by `program.get_build_log()` may have multiple trailing null characters, which results in error with the `to_str()` method.

Happens at least with the current NVIDIA driver version 460.27.04 using OpenCL 1.2.