### PR TITLE
Add InfoType::to_string method

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Via Technology Ltd. All Rights Reserved.
+// Copyright (c) 2020-2021 Via Technology Ltd. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -280,14 +280,14 @@ pub enum DeviceInfo {
 /// assert_eq!(CL_DEVICE_TYPE_GPU, value);
 ///
 /// let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_VENDOR).unwrap();
-/// let value = value.to_str().unwrap();
-/// println!("CL_DEVICE_VENDOR: {:?}", value);
-/// assert!(0 < value.to_bytes().len());
+/// let value = value.to_string();
+/// println!("CL_DEVICE_VENDOR: {}", value);
+/// assert!(!value.is_empty());
 ///
 /// let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_VERSION).unwrap();
-/// let value = value.to_str().unwrap();
-/// println!("CL_DEVICE_VERSION: {:?}", value);
-/// assert!(0 < value.to_bytes().len());
+/// let value = value.to_string();
+/// println!("CL_DEVICE_VERSION: {}", value);
+/// assert!(!value.is_empty());
 /// ```
 /// * `device` - the cl_device_id of the OpenCL device.
 /// * `param_name` - the type of device information being queried, see
@@ -675,10 +675,9 @@ mod tests {
         println!("Device vendor is: {}", vendor_text);
 
         let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_VERSION).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_DEVICE_VERSION: {:?}", value);
-        let value = value.into_string().unwrap();
-        assert!(0 < value.len());
+        let value = value.to_string();
+        println!("CL_DEVICE_VERSION: {}", value);
+        assert!(!value.is_empty());
 
         let opencl_2: String = "OpenCL 2".to_string();
         let is_opencl_2: bool = value.contains(&opencl_2);
@@ -893,34 +892,29 @@ mod tests {
         }
 
         let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_NAME).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_DEVICE_NAME: {:?}", value);
-        let value = value.into_string().unwrap();
-        assert!(0 < value.len());
+        let value = value.to_string();
+        println!("CL_DEVICE_NAME: {}", value);
+        assert!(!value.is_empty());
 
         let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_VENDOR).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_DEVICE_VENDOR: {:?}", value);
-        let value = value.into_string().unwrap();
-        assert!(0 < value.len());
+        let value = value.to_string();
+        println!("CL_DEVICE_VENDOR: {}", value);
+        assert!(!value.is_empty());
 
         let value = get_device_info(device_id, DeviceInfo::CL_DRIVER_VERSION).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_DRIVER_VERSION: {:?}", value);
-        let value = value.into_string().unwrap();
-        assert!(0 < value.len());
+        let value = value.to_string();
+        println!("CL_DRIVER_VERSION: {}", value);
+        assert!(!value.is_empty());
 
         let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_PROFILE).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_DEVICE_PROFILE: {:?}", value);
-        let value = value.into_string().unwrap();
-        assert!(0 < value.len());
+        let value = value.to_string();
+        println!("CL_DEVICE_PROFILE: {}", value);
+        assert!(!value.is_empty());
 
         let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_EXTENSIONS).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_DEVICE_EXTENSIONS: {:?}", value);
-        let value = value.into_string().unwrap();
-        assert!(0 < value.len());
+        let value = value.to_string();
+        println!("CL_DEVICE_EXTENSIONS: {}", value);
+        assert!(!value.is_empty());
 
         let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_PLATFORM).unwrap();
         let value = value.to_ptr();
@@ -984,10 +978,9 @@ mod tests {
         println!("CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF: {}", value);
 
         let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_OPENCL_C_VERSION).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_DEVICE_OPENCL_C_VERSION: {:?}", value);
-        let value = value.into_string().unwrap();
-        assert!(0 < value.len());
+        let value = value.to_string();
+        println!("CL_DEVICE_OPENCL_C_VERSION: {}", value);
+        assert!(!value.is_empty());
 
         let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_LINKER_AVAILABLE).unwrap();
         let value = value.to_uint();
@@ -995,8 +988,8 @@ mod tests {
         assert!(0 < value);
 
         let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_BUILT_IN_KERNELS).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_DEVICE_BUILT_IN_KERNELS: {:?}", value);
+        let value = value.to_string();
+        println!("CL_DEVICE_BUILT_IN_KERNELS: {}", value);
 
         let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_IMAGE_MAX_BUFFER_SIZE).unwrap();
         let value = value.to_size();
@@ -1143,10 +1136,9 @@ mod tests {
             // CL_VERSION_2_1
             if is_opencl_2_1 {
                 let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_IL_VERSION).unwrap();
-                let value = value.to_str().unwrap();
-                println!("CL_DEVICE_IL_VERSION: {:?}", value);
-                let value = value.into_string().unwrap();
-                assert!(0 < value.len());
+                let value = value.to_string();
+                println!("CL_DEVICE_IL_VERSION: {}", value);
+                assert!(!value.is_empty());
 
                 let value = get_device_info(device_id, DeviceInfo::CL_DEVICE_MAX_NUM_SUB_GROUPS).unwrap();
                 let value = value.to_uint();
@@ -1262,10 +1254,9 @@ mod tests {
 
         let value =
             get_device_info(device_id, DeviceInfo::CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: {:?}", value);
-        let value = value.into_string().unwrap();
-        assert!(0 < value.len());
+        let value = value.to_string();
+        println!("CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: {}", value);
+        assert!(!value.is_empty());
     }
 
     #[test]

--- a/src/info_type.rs
+++ b/src/info_type.rs
@@ -36,6 +36,24 @@ pub enum InfoType {
 }
 
 impl InfoType {
+    /// Get a `Vec<cl_uchar>` aka `Vec<u8>` as a String.
+    /// Note: it removes trailing null characters and uses from_utf8_lossy to
+    /// convert any other invalid characters to std::char::REPLACEMENT_CHARACTER.
+    ///
+    /// returns a utf8 String.
+    pub fn to_string(self) -> String {
+        let mut a = self.to_vec_uchar();
+
+        // remove all trailing nulls, if any
+        while let Some(0) = a.last() {
+            a.pop();
+        }
+
+        // convert invalid characters to std::char::REPLACEMENT_CHARACTER
+        String::from_utf8_lossy(&a).into_owned()
+    }
+
+    #[deprecated(since = "0.1.8", note = "Please use the to_string function instead")]
     pub fn to_str(self) -> Result<CString, NulError> {
         let mut a = self.to_vec_uchar();
 

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Via Technology Ltd. All Rights Reserved.
+// Copyright (c) 2020-2021 Via Technology Ltd. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -536,9 +536,9 @@ mod tests {
         let kernel = create_kernel(program, &name).unwrap();
 
         let value = get_kernel_info(kernel, KernelInfo::CL_KERNEL_FUNCTION_NAME).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_KERNEL_FUNCTION_NAME: {:?}", value);
-        assert!(0 < value.to_bytes().len());
+        let value = value.to_string();
+        println!("CL_KERNEL_FUNCTION_NAME: {}", value);
+        assert!(0 < value.len());
 
         let value = get_kernel_info(kernel, KernelInfo::CL_KERNEL_NUM_ARGS).unwrap();
         let value = value.to_uint();
@@ -561,8 +561,8 @@ mod tests {
         assert!(0 < value);
 
         let value = get_kernel_info(kernel, KernelInfo::CL_KERNEL_ATTRIBUTES).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_KERNEL_ATTRIBUTES: {:?}", value);
+        let value = value.to_string();
+        println!("CL_KERNEL_ATTRIBUTES: {}", value);
 
         match get_kernel_arg_info(kernel, 0, KernelArgInfo::CL_KERNEL_ARG_ADDRESS_QUALIFIER) {
             Ok(value) => {
@@ -588,9 +588,9 @@ mod tests {
 
         match get_kernel_arg_info(kernel, 0, KernelArgInfo::CL_KERNEL_ARG_TYPE_NAME) {
             Ok(value) => {
-                let value = value.to_str().unwrap();
-                println!("CL_KERNEL_ARG_TYPE_NAME: {:?}", value);
-                assert!(0 < value.to_bytes().len())
+                let value = value.to_string();
+                println!("CL_KERNEL_ARG_TYPE_NAME: {}", value);
+                assert!(0 < value.len())
             }
             Err(e) => println!("OpenCL error, CL_KERNEL_ARG_TYPE_NAME: {}", error_text(e)),
         }
@@ -608,9 +608,9 @@ mod tests {
 
         match get_kernel_arg_info(kernel, 0, KernelArgInfo::CL_KERNEL_ARG_NAME) {
             Ok(value) => {
-                let value = value.to_str().unwrap();
-                println!("CL_KERNEL_ARG_NAME: {:?}", value);
-                assert!(0 < value.to_bytes().len())
+                let value = value.to_string();
+                println!("CL_KERNEL_ARG_NAME: {}", value);
+                assert!(0 < value.len())
             }
             Err(e) => println!("OpenCL error, CL_KERNEL_ARG_NAME: {}", error_text(e)),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,10 +62,10 @@
 //! See [cl3](https://crates.io/crates/cl3).  
 //!
 //! ## License
-//! 
+//!
 //! Licensed under the Apache License, Version 2.0, as per Khronos Group OpenCL.  
 //! You may obtain a copy of the License at: <http://www.apache.org/licenses/LICENSE-2.0>
-//! 
+//!
 //! OpenCL and the OpenCL logo are trademarks of Apple Inc. used under license by Khronos.
 
 extern crate cl_sys;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Via Technology Ltd. All Rights Reserved.
+// Copyright (c) 2020-2021 Via Technology Ltd. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,15 +95,15 @@ pub enum PlatformInfo {
 /// let platform_id = platform_ids[0];
 ///
 /// let value = get_platform_info(platform_id, PlatformInfo::CL_PLATFORM_NAME).unwrap();
-/// let value = value.to_str().unwrap().into_string().unwrap();
+/// let value = value.to_string();
 /// println!("CL_PLATFORM_NAME: {}", value);
 ///
-/// assert!(0 < value.len());
+/// assert!(!value.is_empty());
 ///
 /// let value = get_platform_info(platform_id, PlatformInfo::CL_PLATFORM_VERSION).unwrap();
-/// let value = value.to_str().unwrap().into_string().unwrap();
+/// let value = value.to_string();
 /// println!("CL_PLATFORM_VERSION: {}", value);
-/// assert!(0 < value.len());
+/// assert!(!value.is_empty());
 /// ```
 /// * `platform` - the cl_platform_id of the OpenCL platform.
 /// * `param_name` - the type of platform information being queried, see
@@ -164,30 +164,29 @@ mod tests {
         let platform_id = platform_ids[0];
 
         let value = get_platform_info(platform_id, PlatformInfo::CL_PLATFORM_PROFILE).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_PLATFORM_PROFILE: {:?}", value);
-        assert!(0 < value.to_bytes().len());
+        let value = value.to_string();
+        println!("CL_PLATFORM_PROFILE: {}", value);
+        assert!(!value.is_empty());
 
         let value = get_platform_info(platform_id, PlatformInfo::CL_PLATFORM_VERSION).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_PLATFORM_VERSION: {:?}", value);
-        let value = value.into_string().unwrap();
-        assert!(0 < value.len());
+        let value = value.to_string();
+        println!("CL_PLATFORM_VERSION: {}", value);
+        assert!(!value.is_empty());
 
         let value = get_platform_info(platform_id, PlatformInfo::CL_PLATFORM_NAME).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_PLATFORM_NAME: {:?}", value);
-        assert!(0 < value.to_bytes().len());
+        let value = value.to_string();
+        println!("CL_PLATFORM_NAME: {}", value);
+        assert!(!value.is_empty());
 
         let value = get_platform_info(platform_id, PlatformInfo::CL_PLATFORM_VENDOR).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_PLATFORM_VENDOR: {:?}", value);
-        assert!(0 < value.to_bytes().len());
+        let value = value.to_string();
+        println!("CL_PLATFORM_VENDOR: {}", value);
+        assert!(!value.is_empty());
 
         let value = get_platform_info(platform_id, PlatformInfo::CL_PLATFORM_EXTENSIONS).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_PLATFORM_EXTENSIONS: {:?}", value);
-        assert!(0 < value.to_bytes().len());
+        let value = value.to_string();
+        println!("CL_PLATFORM_EXTENSIONS: {}", value);
+        assert!(!value.is_empty());
 
         // CL_VERSION_2_1 value, may not be supported
         match get_platform_info(platform_id, PlatformInfo::CL_PLATFORM_HOST_TIMER_RESOLUTION) {
@@ -210,10 +209,9 @@ mod tests {
         let platform_id = platform_ids[0];
 
         let value = get_platform_info(platform_id, PlatformInfo::CL_PLATFORM_VERSION).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_PLATFORM_VERSION: {:?}", value);
-        let value = value.into_string().unwrap();
-        assert!(0 < value.len());
+        let value = value.to_string();
+        println!("CL_PLATFORM_VERSION: {}", value);
+        assert!(!value.is_empty());
 
         let opencl_3: String = "OpenCL 3".to_string();
         let is_opencl_3: bool = value.contains(&opencl_3);

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Via Technology Ltd. All Rights Reserved.
+// Copyright (c) 2020-2021 Via Technology Ltd. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -673,9 +673,8 @@ mod tests {
         assert!(0 < value.len());
 
         let value = get_program_info(program, ProgramInfo::CL_PROGRAM_SOURCE).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_PROGRAM_SOURCE: {:?}", value);
-        let value = value.into_string().unwrap();
+        let value = value.to_string();
+        println!("CL_PROGRAM_SOURCE: {}", value);
         assert!(0 < value.len());
 
         let options = CString::default();
@@ -687,12 +686,12 @@ mod tests {
         assert_eq!(CL_BUILD_SUCCESS, value);
 
         let value = get_program_build_info(program,  device_id, ProgramBuildInfo::CL_PROGRAM_BUILD_OPTIONS).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_PROGRAM_BUILD_OPTIONS: {:?}", value);
+        let value = value.to_string();
+        println!("CL_PROGRAM_BUILD_OPTIONS: {}", value);
 
         let value = get_program_build_info(program,  device_id, ProgramBuildInfo::CL_PROGRAM_BUILD_LOG).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_PROGRAM_BUILD_LOG: {:?}", value);
+        let value = value.to_string();
+        println!("CL_PROGRAM_BUILD_LOG: {}", value);
 
         let value = get_program_build_info(program,  device_id, ProgramBuildInfo::CL_PROGRAM_BINARY_TYPE).unwrap();
         let value = value.to_uint();
@@ -727,16 +726,15 @@ mod tests {
         assert!(0 < value);
 
         let value = get_program_info(program, ProgramInfo::CL_PROGRAM_KERNEL_NAMES).unwrap();
-        let value = value.to_str().unwrap();
-        println!("CL_PROGRAM_KERNEL_NAMES: {:?}", value);
-        let value = value.into_string().unwrap();
+        let value = value.to_string();
+        println!("CL_PROGRAM_KERNEL_NAMES: {}", value);
         assert!(0 < value.len());
 
         // CL_VERSION_2_1 value
         match get_program_info(program, ProgramInfo::CL_PROGRAM_IL) {
             Ok(value) => {
-                let value = value.to_str().unwrap();
-                println!("CL_PROGRAM_IL: {:?}", value)
+                let value = value.to_string();
+                println!("CL_PROGRAM_IL: {}", value)
             }
             Err(e) => println!("OpenCL error, CL_PROGRAM_IL: {}", error_text(e))
         };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Via Technology Ltd. All Rights Reserved.
+// Copyright (c) 2020-2021 Via Technology Ltd. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
 
 extern crate cl3;
 
-use cl3::platform::{get_platform_ids, get_platform_info, PlatformInfo};
-use cl3::device::{get_device_ids, get_device_info, CL_DEVICE_TYPE_GPU, DeviceInfo};
+use cl3::command_queue::{
+    create_command_queue, enqueue_nd_range_kernel, enqueue_read_buffer, enqueue_write_buffer,
+    finish, release_command_queue, CL_QUEUE_PROFILING_ENABLE,
+};
 use cl3::context::{create_context, release_context};
-use cl3::command_queue::{create_command_queue, release_command_queue,
-    enqueue_write_buffer, enqueue_nd_range_kernel, enqueue_read_buffer, finish,
-    CL_QUEUE_PROFILING_ENABLE};
-use cl3::program::{create_program_with_source, build_program, release_program};
+use cl3::device::{get_device_ids, get_device_info, DeviceInfo, CL_DEVICE_TYPE_GPU};
+use cl3::event::{get_event_profiling_info, release_event, wait_for_events, ProfilingInfo};
 use cl3::kernel::{create_kernel, release_kernel, set_kernel_arg};
-use cl3::memory::{create_buffer, release_mem_object, CL_MEM_WRITE_ONLY, CL_MEM_READ_ONLY};
-use cl3::event::{wait_for_events, release_event, get_event_profiling_info, ProfilingInfo};
+use cl3::memory::{create_buffer, release_mem_object, CL_MEM_READ_ONLY, CL_MEM_WRITE_ONLY};
+use cl3::platform::{get_platform_ids, get_platform_info, PlatformInfo};
+use cl3::program::{build_program, create_program_with_source, release_program};
 use cl3::types::{cl_event, cl_float, cl_mem, CL_FALSE, CL_TRUE};
-use std::ffi::CString;
 use libc::{c_void, size_t};
+use std::ffi::CString;
 use std::mem;
 use std::ptr;
 
@@ -51,8 +52,8 @@ fn test_opencl_1_2_example() {
     // Choose the first platform
     let platform_id = platform_ids[0];
     let platform_name = get_platform_info(platform_id, PlatformInfo::CL_PLATFORM_NAME).unwrap();
-    let platform_name = platform_name.to_str().unwrap();
-    println!("Platform Name: {:?}", platform_name);
+    let platform_name = platform_name.to_string();
+    println!("Platform Name: {}", platform_name);
 
     let device_ids = get_device_ids(platform_id, CL_DEVICE_TYPE_GPU).unwrap();
     assert!(0 < device_ids.len());
@@ -60,8 +61,8 @@ fn test_opencl_1_2_example() {
     // Choose the first GPU device
     let device_id = device_ids[0];
     let vendor_name = get_device_info(device_id, DeviceInfo::CL_DEVICE_VENDOR).unwrap();
-    let vendor_name = vendor_name.to_str().unwrap();
-    println!("OpenCL device vendor name: {:?}", vendor_name);
+    let vendor_name = vendor_name.to_string();
+    println!("OpenCL device vendor name: {}", vendor_name);
     let vendor_id = get_device_info(device_id, DeviceInfo::CL_DEVICE_VENDOR_ID).unwrap();
     let vendor_id = vendor_id.to_uint();
     println!("OpenCL device vendor id: {:X}", vendor_id);
@@ -76,7 +77,7 @@ fn test_opencl_1_2_example() {
     // Create a command_queue for the device
     let queue = create_command_queue(context, device_id, CL_QUEUE_PROFILING_ENABLE).unwrap();
 
-    // Create the OpenCL program source 
+    // Create the OpenCL program source
     let src = CString::new(PROGRAM_SOURCE).unwrap();
     let src_ptrs: [*const _; 1] = [src.as_ptr()];
     let program = create_program_with_source(context, 1, src_ptrs.as_ptr(), ptr::null()).unwrap();
@@ -101,24 +102,52 @@ fn test_opencl_1_2_example() {
     }
 
     // Create OpenCL device buffers for input and output data
-    let x = create_buffer(context, CL_MEM_WRITE_ONLY, ARRAY_SIZE * mem::size_of::<cl_float>(), ptr::null_mut())
-        .unwrap();
-    let y = create_buffer(context, CL_MEM_WRITE_ONLY, ARRAY_SIZE * mem::size_of::<cl_float>(), ptr::null_mut())
-        .unwrap();
-    let z = create_buffer(context, CL_MEM_READ_ONLY, ARRAY_SIZE * mem::size_of::<cl_float>(), ptr::null_mut())
-        .unwrap();
+    let x = create_buffer(
+        context,
+        CL_MEM_WRITE_ONLY,
+        ARRAY_SIZE * mem::size_of::<cl_float>(),
+        ptr::null_mut(),
+    )
+    .unwrap();
+    let y = create_buffer(
+        context,
+        CL_MEM_WRITE_ONLY,
+        ARRAY_SIZE * mem::size_of::<cl_float>(),
+        ptr::null_mut(),
+    )
+    .unwrap();
+    let z = create_buffer(
+        context,
+        CL_MEM_READ_ONLY,
+        ARRAY_SIZE * mem::size_of::<cl_float>(),
+        ptr::null_mut(),
+    )
+    .unwrap();
 
     // Blocking write to OpenCL device buffer
-    let x_write_event = enqueue_write_buffer(queue, x, CL_TRUE, 0,
-        ones.len() * mem::size_of::<cl_float>(), ones.as_ptr() as cl_mem,
-        0, ptr::null())
-        .unwrap();
-    
+    let x_write_event = enqueue_write_buffer(
+        queue,
+        x,
+        CL_TRUE,
+        0,
+        ones.len() * mem::size_of::<cl_float>(),
+        ones.as_ptr() as cl_mem,
+        0,
+        ptr::null(),
+    )
+    .unwrap();
     // Non-blocking write to OpenCL device buffer
-    let y_write_event = enqueue_write_buffer(queue, y, CL_FALSE, 0,
-        sums.len() * mem::size_of::<cl_float>(), sums.as_ptr() as cl_mem,
-        0, ptr::null())
-        .unwrap();
+    let y_write_event = enqueue_write_buffer(
+        queue,
+        y,
+        CL_FALSE,
+        0,
+        sums.len() * mem::size_of::<cl_float>(),
+        sums.as_ptr() as cl_mem,
+        0,
+        ptr::null(),
+    )
+    .unwrap();
 
     // wait for y_write_event
     let mut events: Vec<cl_event> = Vec::default();
@@ -130,16 +159,47 @@ fn test_opencl_1_2_example() {
 
     // Set up the arguments to call the OpenCL kernel function
     // i.e. the x, y & z buffers and the constant value, a
-    set_kernel_arg(kernel, 0, mem::size_of::<cl_mem>(), &z as *const _ as *const c_void).unwrap();
-    set_kernel_arg(kernel, 1, mem::size_of::<cl_mem>(), &x as *const _ as *const c_void).unwrap();
-    set_kernel_arg(kernel, 2, mem::size_of::<cl_mem>(), &y as *const _ as *const c_void).unwrap();
-    set_kernel_arg(kernel, 3, mem::size_of::<cl_float>(), &a as *const _ as *const c_void).unwrap();
+    set_kernel_arg(
+        kernel,
+        0,
+        mem::size_of::<cl_mem>(),
+        &z as *const _ as *const c_void,
+    )
+    .unwrap();
+    set_kernel_arg(
+        kernel,
+        1,
+        mem::size_of::<cl_mem>(),
+        &x as *const _ as *const c_void,
+    )
+    .unwrap();
+    set_kernel_arg(
+        kernel,
+        2,
+        mem::size_of::<cl_mem>(),
+        &y as *const _ as *const c_void,
+    )
+    .unwrap();
+    set_kernel_arg(
+        kernel,
+        3,
+        mem::size_of::<cl_float>(),
+        &a as *const _ as *const c_void,
+    )
+    .unwrap();
 
-    // Enqueue the OpenCL kernel for execution 
+    // Enqueue the OpenCL kernel for execution
     let global_work_sizes: [size_t; 1] = [ARRAY_SIZE];
-    let kernel_event = enqueue_nd_range_kernel(queue, kernel,
-         1, ptr::null(), global_work_sizes.as_ptr(),
-        ptr::null(), 0, ptr::null())
+    let kernel_event = enqueue_nd_range_kernel(
+        queue,
+        kernel,
+        1,
+        ptr::null(),
+        global_work_sizes.as_ptr(),
+        ptr::null(),
+        0,
+        ptr::null(),
+    )
     .unwrap();
 
     // Push the kernel_event to the events wait list so that enqueue_read_buffer
@@ -151,10 +211,17 @@ fn test_opencl_1_2_example() {
     // and enqueue a read command to read the device buffer into the array
     // after the kernel event completes.
     let results: [cl_float; ARRAY_SIZE] = [0.0; ARRAY_SIZE];
-    let read_event = enqueue_read_buffer(queue, z, CL_FALSE, 0,
-        results.len() * mem::size_of::<cl_float>(), results.as_ptr() as cl_mem,
-        1, events.as_ptr())
-        .unwrap();
+    let read_event = enqueue_read_buffer(
+        queue,
+        z,
+        CL_FALSE,
+        0,
+        results.len() * mem::size_of::<cl_float>(),
+        results.as_ptr() as cl_mem,
+        1,
+        events.as_ptr(),
+    )
+    .unwrap();
     events.clear();
 
     // Block until all commands on the queue (i.e. the read_event) have completed
@@ -164,10 +231,10 @@ fn test_opencl_1_2_example() {
     assert_eq!(1300.0, results[ARRAY_SIZE - 1]);
     println!("results back: {}", results[ARRAY_SIZE - 1]);
 
-    let start_time = get_event_profiling_info(kernel_event,
-        ProfilingInfo::CL_PROFILING_COMMAND_START).unwrap();
-    let end_time = get_event_profiling_info(kernel_event,
-        ProfilingInfo::CL_PROFILING_COMMAND_END).unwrap();
+    let start_time =
+        get_event_profiling_info(kernel_event, ProfilingInfo::CL_PROFILING_COMMAND_START).unwrap();
+    let end_time =
+        get_event_profiling_info(kernel_event, ProfilingInfo::CL_PROFILING_COMMAND_END).unwrap();
     let duration = end_time.to_ulong() - start_time.to_ulong();
     println!("kernel execution duration (ns): {}", duration);
 
@@ -178,7 +245,6 @@ fn test_opencl_1_2_example() {
     release_event(y_write_event).unwrap();
     release_event(kernel_event).unwrap();
     release_event(read_event).unwrap();
-    
     release_mem_object(z).unwrap();
     release_mem_object(y).unwrap();
     release_mem_object(x).unwrap();


### PR DESCRIPTION
Currently, the `InfoType::to_str` method converts an OpenCL C string into a Result containing a Rust `ffi::CString` and a `NulError`.
The `InfoType::to_str` method now handles null characters in OpenCL C strings returned from some devices, see issue #2.

The new InfoType::to_string method converts an OpenCL C string into Rust String using the `from_utf8_lossy` method to convert invalid characters to std::char::REPLACEMENT_CHARACTER. It is intended to replace `InfoType::to_str` which is now marked with the deprecated attribute.

This change replaces all instances of `InfoType::to_str` in this library with ` InfoType::to_string`.