### PR TITLE
Implement CL_VERSION_* features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2018"
 
 [features]
 
-CL_VERSION_1_2 = []
-CL_VERSION_2_0 = []
-CL_VERSION_2_1 = []
-CL_VERSION_2_2 = []
+CL_VERSION_1_2 = ["cl-sys/opencl_version_1_2"]
+CL_VERSION_2_0 = ["cl-sys/opencl_version_2_0"]
+CL_VERSION_2_1 = ["cl-sys/opencl_version_2_1"]
+CL_VERSION_2_2 = ["cl-sys/opencl_version_2_2"]
 CL_VERSION_3_0 = []
 
 cl_apple_setmemobjectdestructor = []
@@ -56,4 +56,9 @@ libc = "0.2"
 
 [dependencies.cl-sys]
 version = "0.4.2"
-features = ["opencl_version_2_0", "opencl_version_2_1", "opencl_version_2_2"]
+default-features = false
+# The `opencl_version_1_2` always needs to be enables, else `cl-sys` won't
+# compile due to
+# https://github.com/cogciprocate/ocl/blob/03086863e95e43033ae67f1530801cb57032e1a3/cl-sys/src/cl_h.rs#L1051
+# accidentally not being commented out.
+features = ["opencl_version_1_2"]

--- a/src/command_queue.rs
+++ b/src/command_queue.rs
@@ -25,22 +25,35 @@ use super::error_codes::{CL_INVALID_VALUE, CL_SUCCESS};
 use super::info_type::InfoType;
 use super::types::{
     cl_bool, cl_command_queue, cl_command_queue_info, cl_command_queue_properties, cl_context,
-    cl_device_id, cl_event, cl_int, cl_kernel, cl_map_flags, cl_mem, cl_mem_migration_flags,
-    cl_queue_properties, cl_uint, cl_ulong,
+    cl_device_id, cl_event, cl_int, cl_kernel, cl_map_flags, cl_mem, cl_uint, cl_ulong,
 };
+#[cfg(feature = "CL_VERSION_1_2")]
+use super::types::cl_mem_migration_flags;
+#[cfg(feature = "CL_VERSION_2_0")]
+use super::types::cl_queue_properties;
+#[cfg(feature = "CL_VERSION_2_1")]
+use super::types::cl_mem_migration_flags;
 use super::{api_info_size, api_info_value, api_info_vector};
-#[allow(unused_imports)]
 use cl_sys::{
-    clCreateCommandQueue, clCreateCommandQueueWithProperties, clEnqueueBarrierWithWaitList,
-    clEnqueueCopyBuffer, clEnqueueCopyBufferRect, clEnqueueCopyBufferToImage, clEnqueueCopyImage,
-    clEnqueueCopyImageToBuffer, clEnqueueFillBuffer, clEnqueueFillImage, clEnqueueMapBuffer,
-    clEnqueueMapImage, clEnqueueMarkerWithWaitList, clEnqueueMigrateMemObjects,
+    clCreateCommandQueue, clEnqueueCopyBuffer, clEnqueueCopyBufferRect, clEnqueueCopyBufferToImage,
+    clEnqueueCopyImage, clEnqueueCopyImageToBuffer, clEnqueueMapBuffer, clEnqueueMapImage,
     clEnqueueNDRangeKernel, clEnqueueNativeKernel, clEnqueueReadBuffer, clEnqueueReadBufferRect,
-    clEnqueueReadImage, clEnqueueSVMFree, clEnqueueSVMMap, clEnqueueSVMMemFill, clEnqueueSVMMemcpy,
-    clEnqueueSVMMigrateMem, clEnqueueSVMUnmap, clEnqueueTask, clEnqueueUnmapMemObject,
-    clEnqueueWriteBuffer, clEnqueueWriteBufferRect, clEnqueueWriteImage, clFinish, clFlush,
-    clGetCommandQueueInfo, clReleaseCommandQueue, clRetainCommandQueue,
+    clEnqueueReadImage, clEnqueueUnmapMemObject, clEnqueueWriteBuffer, clEnqueueWriteBufferRect,
+    clEnqueueWriteImage, clFinish, clFlush, clGetCommandQueueInfo, clReleaseCommandQueue,
+    clRetainCommandQueue,
 };
+#[cfg(feature = "CL_VERSION_1_2")]
+use cl_sys::{
+    clEnqueueBarrierWithWaitList, clEnqueueFillBuffer, clEnqueueFillImage,
+    clEnqueueMarkerWithWaitList, clEnqueueMigrateMemObjects, clEnqueueTask,
+};
+#[cfg(feature = "CL_VERSION_2_0")]
+use cl_sys::{
+   clCreateCommandQueueWithProperties, clEnqueueSVMFree, clEnqueueSVMMap, clEnqueueSVMMemFill,
+   clEnqueueSVMMemcpy, clEnqueueSVMUnmap,
+};
+#[cfg(feature = "CL_VERSION_2_1")]
+use cl_sys::clEnqueueSVMMigrateMem;
 
 use libc::{c_void, intptr_t, size_t};
 use std::mem;
@@ -57,7 +70,6 @@ use std::ptr;
 ///
 /// returns a Result containing the new OpenCL command-queue
 /// or the error code from the OpenCL C API function.
-#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn create_command_queue(
     context: cl_context,
@@ -392,6 +404,7 @@ pub fn enqueue_write_buffer_rect(
     }
 }
 
+#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn enqueue_fill_buffer(
     command_queue: cl_command_queue,
@@ -568,6 +581,7 @@ pub fn enqueue_write_image(
     }
 }
 
+#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn enqueue_fill_image(
     command_queue: cl_command_queue,
@@ -798,6 +812,7 @@ pub fn enqueue_unmap_mem_object(
     }
 }
 
+#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn enqueue_migrate_mem_object(
     command_queue: cl_command_queue,
@@ -918,6 +933,7 @@ pub fn enqueue_native_kernel(
     }
 }
 
+#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn enqueue_marker_with_wait_list(
     command_queue: cl_command_queue,
@@ -940,6 +956,7 @@ pub fn enqueue_marker_with_wait_list(
     }
 }
 
+#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn enqueue_barrier_with_wait_list(
     command_queue: cl_command_queue,
@@ -962,6 +979,7 @@ pub fn enqueue_barrier_with_wait_list(
     }
 }
 
+#[cfg(feature = "CL_VERSION_2_0")]
 #[inline]
 pub fn enqueue_svm_free(
     command_queue: cl_command_queue,
@@ -999,6 +1017,7 @@ pub fn enqueue_svm_free(
     }
 }
 
+#[cfg(feature = "CL_VERSION_2_0")]
 #[inline]
 pub fn enqueue_svm_mem_cpy(
     command_queue: cl_command_queue,
@@ -1029,6 +1048,7 @@ pub fn enqueue_svm_mem_cpy(
     }
 }
 
+#[cfg(feature = "CL_VERSION_2_0")]
 #[inline]
 pub fn enqueue_svm_mem_fill(
     command_queue: cl_command_queue,
@@ -1059,6 +1079,7 @@ pub fn enqueue_svm_mem_fill(
     }
 }
 
+#[cfg(feature = "CL_VERSION_2_0")]
 #[inline]
 pub fn enqueue_svm_map(
     command_queue: cl_command_queue,
@@ -1089,6 +1110,7 @@ pub fn enqueue_svm_map(
     }
 }
 
+#[cfg(feature = "CL_VERSION_2_0")]
 #[inline]
 pub fn enqueue_svm_unmap(
     command_queue: cl_command_queue,

--- a/src/device.rs
+++ b/src/device.rs
@@ -61,13 +61,14 @@ use super::ffi::cl_ext::{cl_amd_device_topology, cl_device_pci_bus_info_khr,
     CL_DEVICE_LUID_KHR, CL_DEVICE_NODE_MASK_KHR,
 };
 use super::{api_info_size, api_info_value, api_info_vector};
-#[allow(unused_imports)]
-use cl_sys::{
-    clCreateSubDevices, clGetDeviceIDs, clGetDeviceInfo, clReleaseDevice, clRetainDevice, 
-    clSetDefaultDeviceCommandQueue, 
-};
+use cl_sys::{clGetDeviceIDs, clGetDeviceInfo};
+#[cfg(feature = "CL_VERSION_1_2")]
+use cl_sys::{clCreateSubDevices, clReleaseDevice, clRetainDevice};
+#[cfg(feature = "CL_VERSION_2_1")]
+use cl_sys::clSetDefaultDeviceCommandQueue;
 
 // clGetDeviceAndHostTimer, clGetHostTimer, are incorrect in cl_sys
+#[cfg(feature = "CL_VERSION_2_1")]
 #[cfg_attr(not(target_os = "macos"), link(name = "OpenCL"))]
 #[cfg_attr(target_os = "macos", link(name = "OpenCL", kind = "framework"))]
 extern "system" {
@@ -646,6 +647,7 @@ pub const CL_DEVICE_PARTITION_BY_COUNTS_LIST_END: cl_device_partition_property =
 pub const CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN: cl_device_partition_property = 0x1088;
 
 // helper function for create_sub_devices
+#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 fn count_sub_devices(
     in_device: cl_device_id,
@@ -677,6 +679,7 @@ fn count_sub_devices(
 ///
 /// returns a Result containing a vector of available sub-device ids
 /// or the error code from the OpenCL C API function.
+#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn create_sub_devices(
     in_device: cl_device_id,
@@ -712,6 +715,7 @@ pub fn create_sub_devices(
 /// * `device` - the cl_device_id of the OpenCL device.
 ///
 /// returns an empty Result or the error code from the OpenCL C API function.
+#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn retain_device(device: cl_device_id) -> Result<(), cl_int> {
     let status: cl_int = unsafe { clRetainDevice(device) };
@@ -729,6 +733,7 @@ pub fn retain_device(device: cl_device_id) -> Result<(), cl_int> {
 /// * `device` - the cl_device_id of the OpenCL device.
 ///
 /// returns an empty Result or the error code from the OpenCL C API function.
+#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn release_device(device: cl_device_id) -> Result<(), cl_int> {
     let status: cl_int = unsafe { clReleaseDevice(device) };
@@ -1753,6 +1758,7 @@ mod tests {
         assert!(!value.is_empty());
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     #[test]
     fn test_get_sub_devices() {
         let platform_ids = get_platform_ids().unwrap();

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -39,10 +39,13 @@ use super::{
 };
 #[allow(unused_imports)]
 use cl_sys::{
-    clCloneKernel, clCreateKernel, clCreateKernelsInProgram, clGetKernelArgInfo, clGetKernelInfo,
-    clGetKernelSubGroupInfo, clGetKernelWorkGroupInfo, clReleaseKernel, clRetainKernel,
-    clSetKernelArg, clSetKernelArgSVMPointer, clSetKernelExecInfo,
+    clCreateKernel, clCreateKernelsInProgram, clGetKernelArgInfo, clGetKernelInfo,
+    clGetKernelWorkGroupInfo, clReleaseKernel, clRetainKernel, clSetKernelArg
 };
+#[cfg(feature = "CL_VERSION_2_0")]
+use cl_sys::{clSetKernelArgSVMPointer, clSetKernelExecInfo};
+#[cfg(feature = "CL_VERSION_2_1")]
+use cl_sys::{clCloneKernel, clGetKernelSubGroupInfo};
 
 use libc::{c_void, intptr_t, size_t};
 use std::ffi::CStr;
@@ -189,6 +192,7 @@ pub fn set_kernel_arg(
 /// * `arg_ptr` - the SVM pointer to the data for the argument at arg_index.
 ///
 /// returns an empty Result or the error code from the OpenCL C API function.
+#[cfg(feature = "CL_VERSION_2_0")]
 #[inline]
 pub fn set_kernel_arg_svm_pointer(
     kernel: cl_kernel,
@@ -212,6 +216,7 @@ pub fn set_kernel_arg_svm_pointer(
 /// * `param_ptr` - pointer to the data for the param_name.
 ///
 /// returns an empty Result or the error code from the OpenCL C API function.
+#[cfg(feature = "CL_VERSION_2_0")]
 #[inline]
 pub fn set_kernel_exec_info(
     kernel: cl_kernel,
@@ -282,6 +287,7 @@ pub fn get_kernel_info(kernel: cl_kernel, param_name: KernelInfo) -> Result<Info
 
 /// Get data about arguments of an OpenCL kernel.
 /// Calls clGetKernelArgInfo to get the desired data about arguments of the kernel.
+#[cfg(feature = "CL_VERSION_1_2")]
 pub fn get_kernel_arg_data(
     kernel: cl_kernel,
     arg_indx: cl_uint,
@@ -294,6 +300,7 @@ pub fn get_kernel_arg_data(
 }
 
 // cl_kernel_arg_info
+#[cfg(feature = "CL_VERSION_1_2")]
 #[derive(Clone, Copy, Debug)]
 pub enum KernelArgInfo {
     CL_KERNEL_ARG_ADDRESS_QUALIFIER = 0x1196,
@@ -313,6 +320,7 @@ pub enum KernelArgInfo {
 ///
 /// returns a Result containing the desired information in an InfoType enum
 /// or the error code from the OpenCL C API function.
+#[cfg(feature = "CL_VERSION_1_2")]
 pub fn get_kernel_arg_info(
     kernel: cl_kernel,
     arg_indx: cl_uint,
@@ -420,6 +428,7 @@ pub fn get_kernel_work_group_info(
 }
 
 // cl_kernel_sub_group_info
+#[cfg(feature = "CL_VERSION_2_1")]
 #[derive(Clone, Copy, Debug)]
 pub enum KernelSubGroupInfo {
     CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE = 0x2033,
@@ -599,6 +608,7 @@ mod tests {
         let value = value.to_string();
         println!("CL_KERNEL_ATTRIBUTES: {}", value);
 
+        #[cfg(feature = "CL_VERSION_1_2")]
         match get_kernel_arg_info(kernel, 0, KernelArgInfo::CL_KERNEL_ARG_ADDRESS_QUALIFIER) {
             Ok(value) => {
                 let value = value.to_uint();
@@ -610,6 +620,7 @@ mod tests {
             ),
         }
 
+        #[cfg(feature = "CL_VERSION_1_2")]
         match get_kernel_arg_info(kernel, 0, KernelArgInfo::CL_KERNEL_ARG_ACCESS_QUALIFIER) {
             Ok(value) => {
                 let value = value.to_uint();
@@ -621,6 +632,7 @@ mod tests {
             ),
         }
 
+        #[cfg(feature = "CL_VERSION_1_2")]
         match get_kernel_arg_info(kernel, 0, KernelArgInfo::CL_KERNEL_ARG_TYPE_NAME) {
             Ok(value) => {
                 let value = value.to_string();
@@ -630,6 +642,7 @@ mod tests {
             Err(e) => println!("OpenCL error, CL_KERNEL_ARG_TYPE_NAME: {}", error_text(e)),
         }
 
+        #[cfg(feature = "CL_VERSION_1_2")]
         match get_kernel_arg_info(kernel, 0, KernelArgInfo::CL_KERNEL_ARG_TYPE_QUALIFIER) {
             Ok(value) => {
                 let value = value.to_ulong();
@@ -641,6 +654,7 @@ mod tests {
             ),
         }
 
+        #[cfg(feature = "CL_VERSION_1_2")]
         match get_kernel_arg_info(kernel, 0, KernelArgInfo::CL_KERNEL_ARG_NAME) {
             Ok(value) => {
                 let value = value.to_string();

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -42,12 +42,12 @@ use super::types::{
     cl_map_flags, cl_mem, cl_mem_flags, cl_mem_info, cl_mem_object_type, cl_mem_properties,
     cl_pipe_info, cl_svm_mem_flags, cl_uint, cl_ulong,
 };
-#[allow(unused_imports)]
 use cl_sys::{
-    clCreateBuffer, clCreatePipe, clCreateSubBuffer, clGetImageInfo, clGetMemObjectInfo,
-    clGetPipeInfo, clReleaseMemObject, clRetainMemObject, clSVMAlloc, clSVMFree,
-    clSetMemObjectDestructorCallback,
+    clCreateBuffer, clCreateSubBuffer, clGetImageInfo, clGetMemObjectInfo, clReleaseMemObject,
+    clRetainMemObject, clSetMemObjectDestructorCallback,
 };
+#[cfg(feature = "CL_VERSION_2_0")]
+use cl_sys::{clCreatePipe, clGetPipeInfo, clSVMAlloc, clSVMFree};
 
 use super::{api_info_size, api_info_value, api_info_vector};
 
@@ -70,6 +70,7 @@ extern "system" {
         num_image_formats: *mut cl_uint,
     ) -> cl_int;
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn clCreateImage(
         context: cl_context,
         flags: cl_mem_flags,
@@ -80,6 +81,7 @@ extern "system" {
     ) -> cl_mem;
 
     // #ifdef CL_VERSION_3_0
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn clCreateBufferWithProperties(
         context: cl_context,
         properties: *const cl_mem_properties,
@@ -89,6 +91,7 @@ extern "system" {
         errcode_ret: *mut cl_int,
     ) -> cl_mem;
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn clCreateImageWithProperties(
         context: cl_context,
         properties: *const cl_mem_properties,
@@ -183,6 +186,7 @@ pub fn create_sub_buffer(
 ///
 /// returns a Result containing the new OpenCL image object
 /// or the error code from the OpenCL C API function.
+#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn create_image(
     context: cl_context,
@@ -223,6 +227,7 @@ pub fn create_image(
 ///
 /// returns a Result containing the new OpenCL pipe object
 /// or the error code from the OpenCL C API function.
+#[cfg(feature = "CL_VERSION_2_0")]
 #[inline]
 pub fn create_pipe(
     context: cl_context,
@@ -567,6 +572,7 @@ pub fn get_image_info(image: cl_mem, param_name: ImageInfo) -> Result<InfoType, 
 
 /// Get data about an OpenCL pipe object.
 /// Calls clGetPipeInfo to get the desired data about the pipe object.
+#[cfg(feature = "CL_VERSION_2_0")]
 pub fn get_pipe_data(
     pipe: cl_mem,
     param_name: cl_pipe_info,
@@ -578,6 +584,7 @@ pub fn get_pipe_data(
 }
 
 // cl_pipe_info
+#[cfg(feature = "CL_VERSION_2_0")]
 #[derive(Clone, Copy, Debug)]
 pub enum PipeInfo {
     // CL_VERSION_2_0
@@ -597,6 +604,7 @@ pub enum PipeInfo {
 ///
 /// returns a Result containing the desired information in an InfoType enum
 /// or the error code from the OpenCL C API function.
+#[cfg(feature = "CL_VERSION_2_0")]
 pub fn get_pipe_info(pipe: cl_mem, param_name: PipeInfo) -> Result<InfoType, cl_int> {
     let param_id = param_name as cl_pipe_info;
     match param_name {
@@ -652,6 +660,7 @@ pub fn set_mem_object_destructor_callback(
 ///
 /// returns Result containing the address of the SVM buffer
 /// or the error code: CL_INVALID_VALUE if the address is NULL.
+#[cfg(feature = "CL_VERSION_2_0")]
 #[inline]
 pub fn svm_alloc(
     context: cl_context,
@@ -673,6 +682,7 @@ pub fn svm_alloc(
 ///
 /// * `context` - the valid OpenCL context used to create the SVM buffer.
 /// * `svm_pointer` - the value returned by a call to clSVMAlloc.
+#[cfg(feature = "CL_VERSION_2_0")]
 #[inline]
 pub fn svm_free(context: cl_context, svm_pointer: *mut c_void) {
     unsafe { clSVMFree(context, svm_pointer) };

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -20,21 +20,20 @@ use super::error_codes::{CL_INVALID_VALUE, CL_SUCCESS};
 use super::info_type::InfoType;
 use super::types::{
     cl_addressing_mode, cl_bool, cl_context, cl_filter_mode, cl_int, cl_sampler, cl_sampler_info,
-    cl_sampler_properties, cl_uint, cl_ulong,
+    cl_uint, cl_ulong,
 };
+#[cfg(feature = "CL_VERSION_2_0")]
+use super::types::cl_sampler_properties;
 use super::{api_info_size, api_info_value, api_info_vector};
-#[allow(unused_imports)]
-use cl_sys::{
-    clCreateSampler, clCreateSamplerWithProperties, clGetSamplerInfo, clReleaseSampler,
-    clRetainSampler,
-};
+use cl_sys::{clCreateSampler, clGetSamplerInfo, clReleaseSampler, clRetainSampler};
+#[cfg(feature = "CL_VERSION_2_0")]
+use cl_sys::clCreateSamplerWithProperties;
 use libc::{c_void, intptr_t, size_t};
 use std::mem;
 use std::ptr;
 
 /// Create an OpenCL buffer sampler for a context.  
 /// Calls clCreateSampler to create an OpenCL sampler object.  
-/// CL_VERSION_1_2
 ///
 /// * `context` - a valid OpenCL context.
 /// * `normalized_coords` - same interpretation as CL_SAMPLER_NORMALIZED_COORDS.
@@ -45,7 +44,6 @@ use std::ptr;
 /// are described in: [Sampler Properties](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#sampler-properties-table) table.  
 /// returns a Result containing the new OpenCL sampler object
 /// or the error code from the OpenCL C API function.
-#[cfg(feature = "CL_VERSION_1_2")]
 #[inline]
 pub fn create_sampler(
     context: cl_context,


### PR DESCRIPTION
`cl3` specifies compile time features for the different OpenCL versions,
but they weren't fully implemented. This PR implements them. The functions
become the `CL_VERSION_*` number when they were introduced. So if you e.g.
want to use OpenCL 1.2 and 2.0 features, you would need to specify the
`CL_VERSION_1_2` and `CL_VERSION_2_0`. All features prior to OpenCL 1.2
are always enabled.

This commit enables you to compile a `cl3` version with only OpenCL 1.2
features (without any from newer version), which would then run on platforms
that only support OpenCL 1.2 (like MacOS).

It was manually tested that compiling with each `CL_VERSION_*` feature
individually, while disabling the other ones, works.

I've only worked on the `CL_VERSION_*` features. There are lots of more features, but getting all of them right is a lot of work and could be done in a separate PR.