### PR TITLE
Adds thiserror crate and derives impls std::error::Error for ClError …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ default = ["CL_VERSION_1_1", "CL_VERSION_1_2"]
 [dependencies]
 libc = "0.2"
 opencl-sys = "0.2"
+thiserror = "1.0.44"
 
 [[example]]
 name = "clinfo"

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -53,6 +53,7 @@ pub use opencl_sys::cl_dx9_media_sharing::{
 };
 pub use opencl_sys::cl_egl::{CL_EGL_RESOURCE_NOT_ACQUIRED_KHR, CL_INVALID_EGL_OBJECT_KHR};
 use std::fmt;
+use thiserror::Error;
 
 pub fn error_text(error_code: cl_int) -> &'static str {
     match error_code {
@@ -163,7 +164,7 @@ pub fn error_text(error_code: cl_int) -> &'static str {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 /// ClError is a newtype around the OpenCL cl_int error number
 pub struct ClError(pub cl_int);
 


### PR DESCRIPTION
…via derive thiserror::Error

I tested this by compiling both cl3 and opencl3 with my own forks and this tiny example works:

```rust
use anyhow::Context;
use opencl3::device::{get_all_devices, Device, CL_DEVICE_TYPE_GPU};

fn main() -> Result<(), anyhow::Error> {
    let device_id = *get_all_devices(CL_DEVICE_TYPE_GPU)?
        .first()
        .expect("No GPU device found");
    let device = Device::new(device_id);

    let name = device
        .name()
        .context("Failed getting name from device {:?}")
        .unwrap();

    println!("Device name: {}", name);
    Ok(())
}
```

The main reason for implementing std::error:Error is so that we propagate the errors up and use something like anyhow to generalize all errors.