### PR TITLE
Use versioned library name for libOpenCL.so

### DIFF
--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -32,7 +32,7 @@ pub fn load_library() -> &'static Result<OpenClRuntime, Error> {
     } else if cfg!(target_os = "macos") {
         "/System/Library/Frameworks/OpenCL.framework/OpenCL"
     } else {
-        "libOpenCL.so"
+        "libOpenCL.so.1"
     };
 
     OPENCL_RUNTIME.get_or_init(|| {


### PR DESCRIPTION
In general, it is a good practice to refer to a library by its major version when possible, to ensure the version you are using is correct.

It is also sometimes a problem in practice, as certain linux packages avoid shipping the unversioned library symlink in order to enforce this rule. For example, this can be seen on Debian, where `libOpenCL.so.1` is provided by the `libopocl-icd-libopencl1`, which is the base package that's expected to be installed for any OpenCL functionality, while unversioned `libOpenCL.so` is provided by `ocl-icd-opencl-dev`. `-dev` packages should not be required for running software that's already compiled, but in this case it is, as `cl3` tries to load using the unversioned name.

I'm not sure how much this applies to OpenCL installations on Windows, so I'm not touching the dll name.